### PR TITLE
Adding User IDs to Channel Topic

### DIFF
--- a/soap.py
+++ b/soap.py
@@ -17,14 +17,18 @@ class SoapCog(commands.Cog): # SOAP commands
             return
         
         channel_name = user.name.lower().replace(".", "-") + SOAP_CHANNEL_SUFFIX # channels can't have periods
-        channel = discord.utils.get(ctx.guild.channels, name = channel_name)   
+        channel = discord.utils.get(ctx.guild.channels, name = channel_name)
         
         if channel:
             await ctx.send(f"Soap channel already made for `{user.name}` at {channel.jump_url}")
         else:
             category = discord.utils.get(ctx.guild.categories, id=SOAP_CHANNEL_CATEGORY_ID)
             if category:
-                new = await ctx.guild.create_text_channel(name=channel_name, category=category)
+                    new = await ctx.guild.create_text_channel(
+                        name=channel_name,
+                        category=category,
+                        topic=f"This is the SOAP channel for <@{user.id}>, please follow all provided instructions."
+                    )
             else:
                 raise CategoryNotFound(SOAP_CHANNEL_CATEGORY_ID)
             


### PR DESCRIPTION
This PR adds the User ID of the user receiving a SOAP into the topic on creation.
<img width="375" height="116" alt="Screenshot 2025-09-21 at 10 28 09 PM" src="https://github.com/user-attachments/assets/2eb47997-94ea-4b4c-8941-a20329eed819" />
By doing so, we are able to save the User ID of the user without relying on the channel name. As a result, we are able to pull the User ID using regex from the channel topic when using text-only commands.
<img width="236" height="113" alt="Screenshot 2025-09-21 at 10 29 02 PM" src="https://github.com/user-attachments/assets/9188a6f3-8d1c-4c6b-a36b-e97474b08797" />
This, by effect, fixes the issue in which users with usernames containing characters like a period would not get pinged when using text commands, instead of having an output of the following: 
<img width="400" height="223" alt="Screenshot 2025-09-21 at 10 29 58 PM" src="https://github.com/user-attachments/assets/2316a0dd-90f3-499e-8712-3a3ee4f1565a" />

The new code still uses the legacy username system as a fallback as well. The screenshot below shows this working in full-effect on an username that would typically have the issue mentioned above.
<img width="1063" height="915" alt="Screenshot 2025-09-21 at 9 42 21 PM" src="https://github.com/user-attachments/assets/4ecd2c64-d642-43dd-8f4b-c06c7eebed36" />
